### PR TITLE
Update dogstatsd-ruby version in gemspec

### DIFF
--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "puma", ">= 3.12", "< 6"
   spec.add_runtime_dependency "json"
-  spec.add_runtime_dependency "dogstatsd-ruby"
+  spec.add_runtime_dependency "dogstatsd-ruby", "< 5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
`dogstatsd_ruby` version 5 introduced some breaking changes (https://github.com/DataDog/dogstatsd-ruby/blob/master/CHANGELOG.md). With this PR we stick to version 4.